### PR TITLE
Add chain

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,6 +21,9 @@ Metrics/BlockLength:
 Metrics/MethodLength:
   Enabled: false
 
+Style/ExplicitBlockArgument:
+  Enabled: false
+
 # Disabling for now to support Ruby 2.3.
 Style/HashTransformValues:
   Enabled: false

--- a/README.md
+++ b/README.md
@@ -712,6 +712,12 @@ SumsUp::Result.from_block { raise 'unexpected error' }
 
 SumsUp::Result.from_block { 'good result' }
 # => #<variant SumsUp::Result::Success value="good result">
+
+SumsUp::Result.from_block(ArgumentError) { raise ArgumentError, 'bad argument' }
+# => #<variant SumsUp::Result::Failure error=#<ArgumentError: Bad argument>
+
+SumsUp::Result.from_block(ArgumentError) { raise KeyError, 'no such key' }
+# => KeyError: no such key
 ```
 
 `SumsUp::Result#map` applies a function to the successful values:

--- a/README.md
+++ b/README.md
@@ -631,6 +631,23 @@ SumsUp::Maybe.of(false)
 # => #<variant SumsUp::Maybe::Just value=false>
 ```
 
+`SumsUp::Maybe#chain` (and its alias, `#flat_map`) can compose blocks which return `SumsUp::Maybe`s, halting at the first `SumsUp::Maybe.nothing`:
+
+```ruby
+def double_if_odd(n)
+  SumsUp::Maybe
+    .just(n)
+    .chain { |x| x.odd? ? SumsUp::Maybe.just(x) : SumsUp::Maybe.nothing }
+    .chain { |x| SumsUp::Maybe.just(x * 2) }
+end
+
+double_if_odd(3)
+# => #<variant SumsUp::Maybe::Just value=6>
+
+double_if_odd(42)
+# => #<variant SumsUp::Maybe::Nothing>
+```
+
 `SumsUp::Maybe#map` applies a function to the value if it's present:
 
 ```ruby
@@ -718,6 +735,44 @@ SumsUp::Result.from_block(ArgumentError) { raise ArgumentError, 'bad argument' }
 
 SumsUp::Result.from_block(ArgumentError) { raise KeyError, 'no such key' }
 # => KeyError: no such key
+```
+
+`SumsUp::Result#chain` (and its alias, `#flat_map`) can compose blocks which return `SumsUp::Result`s, halting at the first `SumsUp::Result.failure(...)`:
+
+```ruby
+User = Struct.new(:name, :email)
+
+def parse_user(hash)
+  fetch_key(hash, :name).chain do |name|
+    fetch_key(hash, :email).chain do |email|
+      if URI::MailTo::EMAIL_REGEXP.match?(email)
+        SumsUp::Result.success(User.new(name, email))
+      else
+        SumsUp::Result.failure("invalid email: #{email}")
+      end
+    end
+  end
+end
+
+def fetch_key(hash, key)
+  if hash.key?(key)
+    SumsUp::Result.success(hash[key])
+  else
+    SumsUp::Result.failure("key not found: #{key}")
+  end
+end
+
+parse_user(email: '1337h@ck.er')
+# => #<variant SumsUp::Result::Failure error="key not found: name">
+
+parse_user(name: 'Sam')
+# => #<variant SumsUp::Result::Failure error="key not found: email">
+
+parse_user(name: 'Sam', email: '1337h@ck.er')
+# => #<variant SumsUp::Result::Success value=#<struct User name="Sam", email="1337h@ck.er">>
+
+parse_user(name: 'Sam', email: '1337hacker')
+# => #<variant SumsUp::Result::Failure error="invalid email: 1337hacker">
 ```
 
 `SumsUp::Result#map` applies a function to the successful values:

--- a/lib/sums_up/CHANGELOG.md
+++ b/lib/sums_up/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## vX.Y.Z
 
+* Define `SumsUp::{Maybe,Result}#{chain,flat_map}`
 * `SumsUp::Result#from_block` now accepts an optional `Class` argument
 
 ## v1.1.0

--- a/lib/sums_up/CHANGELOG.md
+++ b/lib/sums_up/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## vX.Y.Z
+
+* `SumsUp::Result#from_block` now accepts an optional `Class` argument
+
 ## v1.1.0
 
 * Support rubies as low as 2.3

--- a/lib/sums_up/maybe.rb
+++ b/lib/sums_up/maybe.rb
@@ -17,6 +17,15 @@ module SumsUp
       end
     end
 
+    def chain
+      match do |m|
+        m.just { |value| yield(value) }
+        m.nothing self
+      end
+    end
+
+    alias_method(:flat_map, :chain)
+
     # Map a function across the Maybe. If present, the value is yielded and that
     # result is wrapped in a new Maybe.just. Returns Maybe.nothing otherwise.
     def map

--- a/lib/sums_up/result.rb
+++ b/lib/sums_up/result.rb
@@ -17,6 +17,15 @@ module SumsUp
       failure(e)
     end
 
+    def chain
+      match do |m|
+        m.success { |value| yield(value) }
+        m.failure self
+      end
+    end
+
+    alias_method(:flat_map, :chain)
+
     # Map a function across the successful value (if present).
     def map
       match do |m|

--- a/lib/sums_up/result.rb
+++ b/lib/sums_up/result.rb
@@ -11,9 +11,9 @@ module SumsUp
   Result = SumsUp.define(failure: :error, success: :value) do
     # Yield, wrapping the result in Result.success, or wrap the raised error
     # in Result.failure.
-    def self.from_block
+    def self.from_block(error_class = StandardError)
       success(yield)
-    rescue StandardError => e
+    rescue error_class => e
       failure(e)
     end
 

--- a/spec/sums_up/maybe_spec.rb
+++ b/spec/sums_up/maybe_spec.rb
@@ -23,6 +23,18 @@ RSpec.describe SumsUp::Maybe do
     end
   end
 
+  describe '#chain' do
+    it 'returns nothing when the receiver is nothing' do
+      expect(SumsUp::Maybe.nothing.chain(&:anything))
+        .to(eq(SumsUp::Maybe.nothing))
+    end
+
+    it 'yields the value and returns the result when the receiver is just' do
+      expect(SumsUp::Maybe.just(1).chain { |x| SumsUp::Maybe.just(x * 2) })
+        .to(eq(SumsUp::Maybe.just(2)))
+    end
+  end
+
   describe '#map' do
     it 'returns nothing when the receiver is nothing' do
       expect(SumsUp::Maybe.nothing.map(&:succ))

--- a/spec/sums_up/result_spec.rb
+++ b/spec/sums_up/result_spec.rb
@@ -2,18 +2,45 @@
 
 RSpec.describe SumsUp::Result do
   describe '.from_block' do
-    it 'wraps the error when the block raises' do
-      err = StandardError.new
+    context 'given no arguments' do
+      it 'wraps the error when the block raises' do
+        err = StandardError.new
 
-      expect(SumsUp::Result.from_block { raise(err) })
-        .to(eq(SumsUp::Result.failure(err)))
+        expect(SumsUp::Result.from_block { raise(err) })
+          .to(eq(SumsUp::Result.failure(err)))
+      end
+
+      it 'wraps the result when the block does not raise' do
+        result = double(:result)
+
+        expect(SumsUp::Result.from_block { result })
+          .to(eq(SumsUp::Result.success(result)))
+      end
     end
 
-    it 'wraps the result when the block does not raise' do
-      result = double(:result)
+    context 'given an error class' do
+      let(:error_class) { Class.new(StandardError) }
 
-      expect(SumsUp::Result.from_block { result })
-        .to(eq(SumsUp::Result.success(result)))
+      it 'propagates the error when the block raises a different error' do
+        other_class = Class.new(StandardError)
+
+        expect { SumsUp::Result.from_block(error_class) { raise other_class } }
+          .to(raise_error(other_class))
+      end
+
+      it 'wraps the error when the block raises that error' do
+        error_instance = error_class.new('something went wrong')
+
+        expect(SumsUp::Result.from_block(error_class) { raise(error_instance) })
+          .to(eq(SumsUp::Result.failure(error_instance)))
+      end
+
+      it 'wraps the result when the block does not raise' do
+        result = double(:result)
+
+        expect(SumsUp::Result.from_block { result })
+          .to(eq(SumsUp::Result.success(result)))
+      end
     end
   end
 

--- a/spec/sums_up/result_spec.rb
+++ b/spec/sums_up/result_spec.rb
@@ -54,6 +54,21 @@ RSpec.describe SumsUp::Result do
     end
   end
 
+  describe '#chain' do
+    it 'returns self on failure' do
+      expect(SumsUp::Result.failure(:too_bad).chain(&:anything))
+        .to(eq(SumsUp::Result.failure(:too_bad)))
+    end
+
+    it 'yields the value and returns the result on success' do
+      expect(
+        SumsUp::Result
+          .success(1)
+          .chain { |x| SumsUp::Result.failure("bad value: #{x}") }
+      ).to(eq(SumsUp::Result.failure('bad value: 1')))
+    end
+  end
+
   describe '#map' do
     it 'yields the value and re-wraps the result on success' do
       expect(


### PR DESCRIPTION
This PR implements `#chain` for `Maybe` and `Result`, with an alias for `#flat_map`.

I also included an optional error class argument in `SumsUp::Result.from_block` for convenience.